### PR TITLE
Add avg cpu freq

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple CLI tool to print out host status in one line. Support [slurm](https://
 ```sh
 $ hostat
 hostname   | CPUs |     1m |     5m |    15m | memory % | disk % | UpTime | Avg Mhz |
-cluster01  |    8 |    0.9 |    1.1 |    1.4 |     40 % |   19 % |    4 d | 2283.42
+cluster01  |    8 |    0.9 |    1.1 |    1.4 |     40 % |   19 % |    4 d | 2283.42 |
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A simple CLI tool to print out host status in one line. Support [slurm](https://
 
 ```sh
 $ hostat
-hostname   | CPUs |     1m |     5m |    15m | memory % | disk % | UpTime |
-cluster01  |    8 |    0.9 |    1.1 |    1.4 |     40 % |   19 % |    4 d |
+hostname   | CPUs |     1m |     5m |    15m | memory % | disk % | UpTime | Avg Mhz |
+cluster01  |    8 |    0.9 |    1.1 |    1.4 |     40 % |   19 % |    4 d | 2283.42
 ```
 
 ## Install
@@ -47,9 +47,9 @@ You can use [pdsh](https://linux.die.net/man/1/pdsh) to fetch multiple nodes sta
 
 ```sh
 $ pdsh -w 'cluster[01-05]' -N -R ssh '/usr/local/bin/hostat --header=false' | sort 
-cluster01  |    8 |    1.3 |    1.2 |    1.4 |     40 % |   19 % |    4 d | drain |
-cluster02  |    8 |    8.0 |    8.0 |    8.0 |      8 % |   83 % |   77 d |  idle | 
-cluster03  |    8 |    8.0 |    8.1 |    8.0 |      7 % |   84 % |   77 d | alloc | ssarcandy(8)
-cluster04  |    8 |    8.1 |    8.0 |    8.0 |      7 % |   82 % |   77 d | alloc | ssarcandy(8)
-cluster05  |    8 |    8.2 |    8.1 |    8.1 |      7 % |   81 % |   77 d | alloc | ssarcandy(8)
+cluster01  |    8 |    1.3 |    1.2 |    1.4 |     40 % |   19 % |    4 d | Avg Mhz | drain |
+cluster02  |    8 |    8.0 |    8.0 |    8.0 |      8 % |   83 % |   77 d | 3900.00 |  idle | 
+cluster03  |    8 |    8.0 |    8.1 |    8.0 |      7 % |   84 % |   77 d | 3900.00 | alloc | ssarcandy(8)
+cluster04  |    8 |    8.1 |    8.0 |    8.0 |      7 % |   82 % |   77 d | 3900.00 | alloc | ssarcandy(8)
+cluster05  |    8 |    8.2 |    8.1 |    8.1 |      7 % |   81 % |   77 d | 3900.00 | alloc | ssarcandy(8)
 ```

--- a/main.go
+++ b/main.go
@@ -29,6 +29,12 @@ func main() {
 	i, _ := host.Info()
 	d, _ := disk.Usage("/")
 	t, _ := host.Uptime()
+	p, _ := cpu.Info()
+
+	f := 0.
+	for _, c_inf := range p {
+		f += c_inf.Mhz
+	}
 
 	header := flag.Bool("header", true, "Print Header or not")
 	thresMemory := flag.Int("thres_mem", 80, "Threshold for Memory. Render red color if >= thres")
@@ -39,7 +45,7 @@ func main() {
 	_, err := exec.LookPath("sinfo")
 
 	if *header {
-		fmt.Printf("%-10s |%5s |%7s |%7s |%7s |%9s |%7s |%7s |", "hostname", "CPUs", "1m", "5m", "15m", "memory %", "disk %", "UpTime")
+		fmt.Printf("%-10s |%5s |%7s |%7s |%7s |%9s |%7s |%7s |%8s |", "hostname", "CPUs", "1m", "5m", "15m", "memory %", "disk %", "UpTime", "Avg Mhz")
 		if err == nil {
 			fmt.Printf("%6s | %s", "State", "Jobs")
 		}
@@ -52,6 +58,7 @@ func main() {
 	fmt.Printf("%7.0f %% |", RedScale(m.UsedPercent, *thresMemory))
 	fmt.Printf("%5.0f %% |", RedScale(d.UsedPercent, *thresDisk))
 	fmt.Printf("%7s |", fmt.Sprintf("%v d", t/86400))
+	fmt.Printf("%8.2f", f / float64(c))
 
 	if err == nil {
 		PrintSlurmInfo(i.Hostname)

--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ import (
 )
 
 /*
- * hostname  | CPUs | 1m Load | 5m Load | 15m Load | memory % | disk % | users | uptime | status | jobs
- * cluster01 |    8 |     1.1 |     1.5 |      2.1 |     60 % |   56 % |     2 | 16days |  alloc | ssarcandy(8)
- * cluster02 |    8 |     5.1 |     5.5 |      5.1 |     20 % |   96 % |     0 | 16days |  alloc | ssarcandy(8)
+ * hostname  | CPUs | 1m Load | 5m Load | 15m Load | memory % | disk % | users | uptime | Avg Mhz | status | jobs
+ * cluster01 |    8 |     1.1 |     1.5 |      2.1 |     60 % |   56 % |     2 | 16days | 2283.42 |  alloc | ssarcandy(8)
+ * cluster02 |    8 |     5.1 |     5.5 |      5.1 |     20 % |   96 % |     0 | 16days | 2283.42 |  alloc | ssarcandy(8)
  */
 
 func main() {
@@ -29,12 +29,8 @@ func main() {
 	i, _ := host.Info()
 	d, _ := disk.Usage("/")
 	t, _ := host.Uptime()
-	p, _ := cpu.Info()
 
-	f := 0.
-	for _, c_inf := range p {
-		f += c_inf.Mhz
-	}
+	f := GetTotalCpuMhz()
 
 	header := flag.Bool("header", true, "Print Header or not")
 	thresMemory := flag.Int("thres_mem", 80, "Threshold for Memory. Render red color if >= thres")
@@ -58,7 +54,7 @@ func main() {
 	fmt.Printf("%7.0f %% |", RedScale(m.UsedPercent, *thresMemory))
 	fmt.Printf("%5.0f %% |", RedScale(d.UsedPercent, *thresDisk))
 	fmt.Printf("%7s |", fmt.Sprintf("%v d", t/86400))
-	fmt.Printf("%8.2f", f / float64(c))
+	fmt.Printf("%8.2f |", f / float64(c))
 
 	if err == nil {
 		PrintSlurmInfo(i.Hostname)
@@ -66,6 +62,15 @@ func main() {
 	}
 
 	fmt.Println("")
+}
+
+func GetTotalCpuMhz() float64 {
+	Mhz := 0.
+	p, _ := cpu.Info()
+	for _, cpu_inf := range p {
+		Mhz += cpu_inf.Mhz
+	}
+	return Mhz
 }
 
 func RedScale(v float64, thres int) aurora.Value {

--- a/main.go
+++ b/main.go
@@ -48,13 +48,13 @@ func main() {
 		fmt.Println("")
 	}
 
-	fmt.Printf("%-10s |", i.Hostname)
+	fmt.Printf("%-10s |", i.Hostname[:10])
 	fmt.Printf("%5v |", c)
 	fmt.Printf("%7.1f |%7.1f |%7.1f |", RedScale(l.Load1, *thresLoad), RedScale(l.Load5, *thresLoad), RedScale(l.Load15, *thresLoad))
 	fmt.Printf("%7.0f %% |", RedScale(m.UsedPercent, *thresMemory))
 	fmt.Printf("%5.0f %% |", RedScale(d.UsedPercent, *thresDisk))
 	fmt.Printf("%7s |", fmt.Sprintf("%v d", t/86400))
-	fmt.Printf("%8.2f |", f / float64(c))
+	fmt.Printf("%8.2f |", f/float64(c))
 
 	if err == nil {
 		PrintSlurmInfo(i.Hostname)

--- a/main.go
+++ b/main.go
@@ -48,7 +48,12 @@ func main() {
 		fmt.Println("")
 	}
 
-	fmt.Printf("%-10s |", i.Hostname[:10])
+	adjName := i.Hostname
+	if len(adjName) > 10 {
+		adjName = adjName[:10]
+	}
+
+	fmt.Printf("%-10s |", adjName)
 	fmt.Printf("%5v |", c)
 	fmt.Printf("%7.1f |%7.1f |%7.1f |", RedScale(l.Load1, *thresLoad), RedScale(l.Load5, *thresLoad), RedScale(l.Load15, *thresLoad))
 	fmt.Printf("%7.0f %% |", RedScale(m.UsedPercent, *thresMemory))


### PR DESCRIPTION
1. add monitor average cpu frequency among all cores
2. align output format incase hostname too long

known issue:
1. On Windows platform, Load and AvgMhz seems not working.